### PR TITLE
Fixed issue with context

### DIFF
--- a/JavaScript/6-hide-symbols.js
+++ b/JavaScript/6-hide-symbols.js
@@ -21,11 +21,8 @@ const hideSymbol = (obj, symbol) => {
     },
 
     get: (target, property) => {
-      if (property === symbol && target.simulateSecretField) {
+      if (property === symbol) {
         return target.simulateSecretField;
-      }
-      if (property === symbol && target.simulateSecretField === undefined) {
-        return undefined;
       }
       return target.realObj[property];
     },

--- a/JavaScript/7-hide-symbols-usage.js
+++ b/JavaScript/7-hide-symbols-usage.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const hideSymbol = require('./7-hide-symbols.js');
+const hideSymbol = require('./6-hide-symbols.js');
 
 let obj = {
   name: 'Marcus Aurelius',

--- a/JavaScript/7-hide-symbols-usage.js
+++ b/JavaScript/7-hide-symbols-usage.js
@@ -49,7 +49,9 @@ console.log(Object.entries(obj));
 
 Object.defineProperty(obj, '_debugOutputSecretField', {
   enumerable: false,
-  get: () => this[Symbol.for('secret')],
+  get() {
+    return this[Symbol.for('secret')];
+  },
   configurable: true
 });
 


### PR DESCRIPTION
The 'undefined' output of the get method, which is directed to the outside object because of the arrow function, now gives the property of the inside object.
